### PR TITLE
Fix change of mysql user password if user exists

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -1537,7 +1537,7 @@ def user_chpass(user,
     args['user'] = user
     args['host'] = host
     if salt.utils.versions.version_cmp(server_version, compare_version) >= 0:
-        qry = "ALTER USER %(user)s@%(host)s IDENTIFIED BY %(password)s;"
+        qry = "ALTER USER %(user)s@%(host)s IDENTIFIED BY %(password_sql)s;"
     else:
         qry = ('UPDATE mysql.user SET ' + password_column + '=' + password_sql +
                ' WHERE User=%(user)s AND Host = %(host)s;')


### PR DESCRIPTION
### What does this PR do?

Fixes the change of mysql user password if user exists.
I stumbled upon this using 2019.02. The lines are a bit different. I honestly don't know if it was just a typo, but changing `password` to `password_sql` fixed it. Maybe backporting this would be useful, too.

This was the error I got:
```
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python3/dist-packages/salt/state.py", line 1933, in call
                  **cdata['kwargs'])
                File "/usr/lib/python3/dist-packages/salt/loader.py", line 1939, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python3/dist-packages/salt/states/mysql_user.py", line 174, in present
                  **connection_args):
                File "/usr/lib/python3/dist-packages/salt/modules/mysql.py", line 1475, in user_chpass
                  " IDENTIFIED BY '" + password + "';")
              TypeError: must be str, not NoneType
```

### What issues does this PR fix or reference?


### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
